### PR TITLE
Add Vue 3 router boilerplate

### DIFF
--- a/my-vue-app/src/router/guards.ts
+++ b/my-vue-app/src/router/guards.ts
@@ -1,0 +1,25 @@
+import { useAuthStore } from '@/modules/auth/store/useAuthStore';
+
+/**
+ * Guard that ensures the user is authenticated.
+ */
+export function authGuard(): boolean {
+  const auth = useAuthStore();
+  return auth.isAuthenticated;
+}
+
+/**
+ * Guard that checks the user is not authenticated (guest).
+ */
+export function guestGuard(): boolean {
+  const auth = useAuthStore();
+  return !auth.isAuthenticated;
+}
+
+/**
+ * Guard that verifies the user has admin role.
+ */
+export function adminGuard(): boolean {
+  const auth = useAuthStore();
+  return auth.user?.role === 'admin';
+}

--- a/my-vue-app/src/router/index.ts
+++ b/my-vue-app/src/router/index.ts
@@ -1,0 +1,35 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import routes from './routes';
+import { authGuard, guestGuard, adminGuard } from './guards';
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+router.beforeEach((to, from, next) => {
+  const { requiresAuth, guestOnly, roles } = to.meta as {
+    requiresAuth?: boolean;
+    guestOnly?: boolean;
+    roles?: string[];
+  };
+
+  if (guestOnly && !guestGuard()) {
+    next({ name: 'home' });
+    return;
+  }
+
+  if (requiresAuth && !authGuard()) {
+    next({ name: 'login', query: { redirect: to.fullPath } });
+    return;
+  }
+
+  if (roles && roles.includes('admin') && !adminGuard()) {
+    next({ name: 'not-found' });
+    return;
+  }
+
+  next();
+});
+
+export default router;

--- a/my-vue-app/src/router/routes.ts
+++ b/my-vue-app/src/router/routes.ts
@@ -1,0 +1,100 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+/**
+ * Publicly accessible routes.
+ */
+const publicRoutes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: 'home',
+    component: () => import('@/views/Home.vue'),
+    meta: {
+      layout: 'public',
+    },
+  },
+  {
+    path: '/about',
+    name: 'about',
+    component: () => import('@/views/About.vue'),
+    meta: {
+      layout: 'public',
+    },
+  },
+  {
+    path: '/faq',
+    name: 'faq',
+    component: () => import('@/views/FAQ.vue'),
+    meta: {
+      layout: 'public',
+    },
+  },
+  {
+    path: '/blog',
+    name: 'blog',
+    component: () => import('@/views/Blog.vue'),
+    meta: {
+      layout: 'public',
+    },
+  },
+];
+
+/**
+ * Routes used for authentication (only accessible to guests).
+ */
+const authRoutes: RouteRecordRaw[] = [
+  {
+    path: '/login',
+    name: 'login',
+    component: () => import('@/modules/auth/pages/LoginPage.vue'),
+    meta: {
+      guestOnly: true,
+      layout: 'auth',
+    },
+  },
+  {
+    path: '/register',
+    name: 'register',
+    component: () => import('@/modules/auth/pages/RegisterPage.vue'),
+    meta: {
+      guestOnly: true,
+      layout: 'auth',
+    },
+  },
+];
+
+/**
+ * Routes requiring authentication.
+ */
+const protectedRoutes: RouteRecordRaw[] = [
+  {
+    path: '/profile',
+    name: 'profile',
+    component: () => import('@/views/Profile.vue'),
+    meta: {
+      requiresAuth: true,
+      roles: ['user', 'admin'],
+      layout: 'default',
+    },
+  },
+];
+
+/**
+ * Fallback route for 404 pages.
+ */
+const fallbackRoute: RouteRecordRaw = {
+  path: '/:pathMatch(.*)*',
+  name: 'not-found',
+  component: () => import('@/views/NotFound.vue'),
+  meta: {
+    layout: 'public',
+  },
+};
+
+export const routes: RouteRecordRaw[] = [
+  ...publicRoutes,
+  ...authRoutes,
+  ...protectedRoutes,
+  fallbackRoute,
+];
+
+export default routes;


### PR DESCRIPTION
## Summary
- add lazy-loaded public, auth, and protected routes
- implement reusable Pinia-based guards
- initialize Vue Router with global guard logic

## Testing
- `npm run type-check` *(fails: Ref type-only import, missing component paths, store persist option)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef4e68488333a00e1e5f00d42904