### PR TITLE
Add Persian date utility

### DIFF
--- a/my-vue-app/package-lock.json
+++ b/my-vue-app/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
         "axios": "^1.6.8",
+        "dayjs": "^1.11.13",
+        "jalaliday": "^2.3.0",
         "pinia": "^2.1.7",
         "vee-validate": "^4.15.1",
         "vue": "^3.5.13",
@@ -2312,6 +2314,12 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -2974,6 +2982,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/jalaliday": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jalaliday/-/jalaliday-2.3.0.tgz",
+      "integrity": "sha512-B/m3TqsRrTFED/HBDqON6rPKe0MpoLxNICZ5uZeZ/scHJUHKQNr1n+wdZSj8MxrY1Bmo05gllZeNEw4beXd2oQ==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.4.2",

--- a/my-vue-app/package.json
+++ b/my-vue-app/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
     "axios": "^1.6.8",
+    "dayjs": "^1.11.13",
+    "jalaliday": "^2.3.0",
     "pinia": "^2.1.7",
     "vee-validate": "^4.15.1",
     "vue": "^3.5.13",

--- a/my-vue-app/src/utils/formatPersianDate.ts
+++ b/my-vue-app/src/utils/formatPersianDate.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs';
+import jalaliday from 'jalaliday';
+import 'dayjs/locale/fa';
+
+dayjs.extend(jalaliday);
+
+export function formatPersianDate(date: dayjs.ConfigType, format = 'YYYY/MM/DD'): string {
+  return dayjs(date).calendar('jalali').locale('fa').format(format);
+}


### PR DESCRIPTION
## Summary
- integrate Day.js with jalali calendar
- format Persian dates via util

## Testing
- `npm run build` *(fails: Cannot find module '@/views/FAQ.vue' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845f877031c8333a02a596cbc976abe