### PR TITLE
Add date formatting utility with Jalali support

### DIFF
--- a/my-vue-app/package-lock.json
+++ b/my-vue-app/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
         "axios": "^1.6.8",
+        "dayjs": "^1.11.10",
+        "dayjs-jalali": "^0.0.2",
         "pinia": "^2.1.7",
         "vee-validate": "^4.15.1",
         "vue": "^3.5.13",
@@ -2312,6 +2314,21 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs-jalali": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dayjs-jalali/-/dayjs-jalali-0.0.2.tgz",
+      "integrity": "sha512-pwsgYXAES7Jziyv+6l72t3ovoXRC4QTr0zjlCkbaWSvTxmgdnGOhp6nWIXO5b+fmCv0COWfYs7wwPP38fJrNVA==",
+      "license": "MIT",
+      "dependencies": {
+        "jalaali-js": "^1.1.0"
+      }
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -2974,6 +2991,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/jalaali-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.2.8.tgz",
+      "integrity": "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.4.2",

--- a/my-vue-app/package.json
+++ b/my-vue-app/package.json
@@ -17,7 +17,9 @@
     "vee-validate": "^4.15.1",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
+    "dayjs": "^1.11.10",
+    "dayjs-jalali": "^0.0.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.8",

--- a/my-vue-app/src/types/dayjs-jalali.d.ts
+++ b/my-vue-app/src/types/dayjs-jalali.d.ts
@@ -1,0 +1,1 @@
+declare module 'dayjs-jalali';

--- a/my-vue-app/src/utils/formatDate.ts
+++ b/my-vue-app/src/utils/formatDate.ts
@@ -1,0 +1,26 @@
+import dayjs from 'dayjs';
+import jalali from 'dayjs-jalali';
+
+dayjs.extend(jalali);
+
+export type CalendarType = 'gregorian' | 'jalali';
+
+export function formatDate(
+  date: Date | string,
+  calendar: CalendarType = 'gregorian',
+  format = 'YYYY-MM-DD'
+): string {
+  const parsed = typeof date === 'string'
+    ? dayjs(date, calendar === 'jalali' ? ({ jalali: true } as any) : undefined)
+    : dayjs(date);
+
+  if (!parsed.isValid()) {
+    return 'Invalid date';
+  }
+
+  if (calendar === 'jalali') {
+    return parsed.locale('fa').format(format);
+  }
+
+  return parsed.format(format);
+}


### PR DESCRIPTION
## Summary
- add `dayjs` and `dayjs-jalali` dependencies
- create a simple module declaration for `dayjs-jalali`
- implement `formatDate` utility for Gregorian and Jalali calendars

## Testing
- `npm run type-check` *(fails: Cannot find modules and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845f8ebe274833382c06b8706432edf