### PR TITLE
Add responsive mobile footer layout

### DIFF
--- a/my-vue-app/package-lock.json
+++ b/my-vue-app/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.8",
         "dayjs": "^1.11.10",
         "dayjs-jalali": "^0.0.2",
+        "jalaliday": "^2.3.0",
         "pinia": "^2.1.7",
         "vee-validate": "^4.15.1",
         "vue": "^3.5.13",
@@ -28,6 +29,7 @@
         "npm-run-all2": "^7.0.2",
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.8",
+        "tailwindcss-safe-area": "^0.6.0",
         "typescript": "~5.8.0",
         "vite": "^6.2.4",
         "vite-plugin-vue-devtools": "^7.7.2",
@@ -1638,6 +1640,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.8.tgz",
@@ -2998,6 +3060,12 @@
       "integrity": "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==",
       "license": "MIT"
     },
+    "node_modules/jalaliday": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jalaliday/-/jalaliday-2.3.0.tgz",
+      "integrity": "sha512-B/m3TqsRrTFED/HBDqON6rPKe0MpoLxNICZ5uZeZ/scHJUHKQNr1n+wdZSj8MxrY1Bmo05gllZeNEw4beXd2oQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -3937,6 +4005,22 @@
       "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss-safe-area": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-safe-area/-/tailwindcss-safe-area-0.6.0.tgz",
+      "integrity": "sha512-5PM3CKquzmaa6mow64zWJ0438/yGSqdPfjaXtwNDb31LezNWqFoGPSbvrW12T8iB4EBjeWot+qAA9nbUqqf3sw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mvllow"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^2.0.0 || >=3.0.0"
+      }
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/my-vue-app/package.json
+++ b/my-vue-app/package.json
@@ -33,6 +33,7 @@
     "npm-run-all2": "^7.0.2",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
+    "tailwindcss-safe-area": "^0.6.0",
     "typescript": "~5.8.0",
     "vite": "^6.2.4",
     "vite-plugin-vue-devtools": "^7.7.2",

--- a/my-vue-app/src/components/MobileFooter.vue
+++ b/my-vue-app/src/components/MobileFooter.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { RouterLink, useRoute } from 'vue-router'
+
+const route = useRoute()
+</script>
+
+<template>
+  <nav class="fixed bottom-0 left-0 right-0 z-30 flex justify-around bg-white shadow pt-safe pb-safe">
+    <RouterLink
+      to="/"
+      class="flex flex-1 flex-col items-center gap-1 py-2"
+      :class="{ 'text-blue-600 font-semibold': route.name === 'home' }"
+    >
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12L11.2045 3.04549c.4393-.43934 1.1517-.43934 1.591 0L21.75 12M4.5 9.75v10.125a.75.75 0 00.75.75H9.75v-4.875c0-.6213.5037-1.125 1.125-1.125h2.25c.6213 0 1.125.5037 1.125 1.125V20.625h4.125a.75.75 0 00.75-.75V9.75M8.25 21h8.25" />
+      </svg>
+      <span class="text-xs">Home</span>
+    </RouterLink>
+    <RouterLink
+      to="/about"
+      class="flex flex-1 flex-col items-center gap-1 py-2"
+      :class="{ 'text-blue-600 font-semibold': route.name === 'about' }"
+    >
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.0415-.0207c.5731-.2866 1.2184.231 1.063 0.8527l-.709 2.8359c-.1554.6217.4899 1.1393 1.063 0.8527L12.75 15.75M21 12c0 4.9706-4.0294 9-9 9s-9-4.0294-9-9 4.0294-9 9-9 9 4.0294 9 9ZM12 8.25h.0075v.0075H12V8.25z" />
+      </svg>
+      <span class="text-xs">About</span>
+    </RouterLink>
+    <RouterLink
+      to="/faq"
+      class="flex flex-1 flex-col items-center gap-1 py-2"
+      :class="{ 'text-blue-600 font-semibold': route.name === 'faq' }"
+    >
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.172-1.025 3.071-1.025 4.243 0 1.172 1.025 1.172 2.687 0 3.712-.204.178-.43.325-.67.441-.746.361-1.451.999-1.451 1.828V14.25M21 12c0 4.9706-4.0294 9-9 9s-9-4.0294-9-9 4.0294-9 9-9 9 4.0294 9 9ZM12 17.25h.0075v.0075H12V17.25z" />
+      </svg>
+      <span class="text-xs">FAQ</span>
+    </RouterLink>
+    <RouterLink
+      to="/blog"
+      class="flex flex-1 flex-col items-center gap-1 py-2"
+      :class="{ 'text-blue-600 font-semibold': route.name === 'blog' }"
+    >
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5h1.5M12 10.5h1.5M6 13.5h7.5M6 16.5h7.5M16.5 7.5H19.875C20.4963 7.5 21 8.0037 21 8.625V18c0 1.2426-.9926 2.25-2.25 2.25M16.5 7.5V18c0 1.2426-.9926 2.25-2.25 2.25M16.5 7.5V4.875c0-.6213-.5037-1.125-1.125-1.125H4.125C3.5037 3.75 3 4.2537 3 4.875V18c0 1.2426 1.0074 2.25 2.25 2.25H18.75M6 7.5h3v3H6V7.5z" />
+      </svg>
+      <span class="text-xs">Blog</span>
+    </RouterLink>
+    <RouterLink
+      to="/profile"
+      class="flex flex-1 flex-col items-center gap-1 py-2"
+      :class="{ 'text-blue-600 font-semibold': route.name === 'profile' }"
+    >
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118C4.571 16.037 7.902 12.75 12 12.75s7.429 3.287 7.499 7.368c-2.283 1.048-4.823 1.632-7.499 1.632-2.676 0-5.216-.584-7.499-1.632z" />
+      </svg>
+      <span class="text-xs">Profile</span>
+    </RouterLink>
+  </nav>
+</template>
+

--- a/my-vue-app/src/layouts/DefaultLayout.vue
+++ b/my-vue-app/src/layouts/DefaultLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import TheHeader from '@/components/TheHeader.vue'
 import TheSidebar from '@/components/TheSidebar.vue'
+import MobileFooter from '@/components/MobileFooter.vue'
 import { useLayout } from '@/composables/useLayout'
 
 // Manage sidebar/drawer visibility
@@ -9,7 +10,7 @@ const { isDrawerOpen, toggleDrawer, closeDrawer } = useLayout()
 
 <template>
   <!-- Overall page container -->
-  <div class="min-h-screen bg-gray-50 lg:grid lg:grid-cols-[16rem_1fr]">
+  <div class="relative flex min-h-screen flex-col bg-gray-50 lg:flex-row">
     <!-- Mobile overlay when sidebar is open -->
     <Transition
       enter-active-class="transition-opacity duration-200"
@@ -27,7 +28,7 @@ const { isDrawerOpen, toggleDrawer, closeDrawer } = useLayout()
 
     <!-- Sidebar navigation -->
     <aside
-      class="fixed inset-y-0 left-0 z-50 w-64 transform bg-white shadow-md transition-transform duration-200 lg:static lg:translate-x-0"
+      class="fixed inset-y-0 left-0 z-40 w-64 transform bg-white shadow-md transition-transform duration-200 lg:static lg:translate-x-0"
       :class="{ '-translate-x-full': !isDrawerOpen, 'translate-x-0': isDrawerOpen }"
       role="navigation"
       aria-label="Main sidebar"
@@ -36,16 +37,18 @@ const { isDrawerOpen, toggleDrawer, closeDrawer } = useLayout()
     </aside>
 
     <!-- Main column -->
-    <div class="flex min-h-screen flex-col lg:ml-64">
+    <div class="flex flex-1 flex-col">
       <!-- Sticky header -->
       <header class="sticky top-0 z-30 w-full" role="banner">
         <TheHeader @toggle="toggleDrawer" />
       </header>
 
       <!-- Scrollable content area -->
-      <main id="main" role="main" class="flex-1 overflow-auto p-4">
+      <main id="main" role="main" class="flex-1 overflow-auto p-4 pb-24 lg:pb-4">
         <router-view />
       </main>
+      <!-- Mobile bottom navigation -->
+      <MobileFooter class="lg:hidden" />
     </div>
   </div>
 </template>

--- a/my-vue-app/tailwind.config.ts
+++ b/my-vue-app/tailwind.config.ts
@@ -1,9 +1,10 @@
 import type { Config } from 'tailwindcss'
+import safeArea from 'tailwindcss-safe-area'
 
 export default {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [safeArea],
 } satisfies Config


### PR DESCRIPTION
## Summary
- add `tailwindcss-safe-area` plugin
- create `MobileFooter.vue` component with 5 navigation items
- update `DefaultLayout.vue` for responsive design and mobile footer

## Testing
- `npm run type-check` *(fails: cannot find some modules, TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847d47970b88333b8fdf51ebe251fd7